### PR TITLE
Refactor step execution

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 
 	"github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/spf13/cobra"
+	"github.com/xflagstudio/zenform/command/apply"
 	"github.com/xflagstudio/zenform/command/common"
 	"github.com/xflagstudio/zenform/command/step"
 	"github.com/xflagstudio/zenform/config"
@@ -133,13 +133,13 @@ func applyFunc(cmd *cobra.Command, args []string) {
 	})
 
 	exe.Step("Applying patch to Zendesk", func() error {
-		if err := exe.StepIf(len(conf.TicketFields) > 0, "Creating ticket fields...", stepCreateTicketFields(exe, zd, conf, currentState)); err != nil {
+		if err := exe.StepIf(len(conf.TicketFields) > 0, "Creating ticket fields...", apply.StepCreateTicketFields(exe, zd, conf, currentState)); err != nil {
 			return err
 		}
-		if err := exe.StepIf(len(conf.TicketForms) > 0, "Creating ticket forms...", stepCreateTicketForms(exe, zd, conf, currentState)); err != nil {
+		if err := exe.StepIf(len(conf.TicketForms) > 0, "Creating ticket forms...", apply.StepCreateTicketForms(exe, zd, conf, currentState)); err != nil {
 			return err
 		}
-		if err := exe.StepIf(len(conf.Triggers) > 0, "Creating triggers...", stepCreateTriggers(exe, zd, conf, currentState)); err != nil {
+		if err := exe.StepIf(len(conf.Triggers) > 0, "Creating triggers...", apply.StepCreateTriggers(exe, zd, conf, currentState)); err != nil {
 			return err
 		}
 		return nil
@@ -156,141 +156,4 @@ func applyFunc(cmd *cobra.Command, args []string) {
 		exe.Success("Done")
 		return nil
 	})
-}
-
-func stepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
-	return func() error {
-		for _, ticketField := range conf.TicketFields {
-			if state.ExistsTicketField(ticketField.Slug) {
-				continue
-			}
-
-			exe.Step("Creating \""+ticketField.Title+"\"", func() error {
-				//TODO: refactor, move to func
-				requestPayload := zendesk.TicketField{
-					Type:  ticketField.Type,
-					Title: ticketField.Title,
-				}
-				for _, customFieldOption := range ticketField.CustomFieldOptions {
-					requestPayload.CustomFieldOptions = append(requestPayload.CustomFieldOptions, zendesk.TicketFieldCustomFieldOption{
-						Name:  customFieldOption.Name,
-						Value: customFieldOption.Value,
-					})
-				}
-
-				result, err := zd.CreateTicketField(requestPayload)
-				if err != nil {
-					exe.Error("Failed to create ticket field: " + ticketField.Title)
-					exe.Error("Error: " + err.Error())
-					return err
-				}
-				state.TicketFields[ticketField.Slug] = result
-				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
-				return nil
-			})
-		}
-		exe.Success("Created (" + fmt.Sprintf("%d", len(state.TicketFields)) + ") ticket fields")
-		return nil
-	}
-}
-
-func stepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
-	return func() error {
-		for _, ticketForm := range conf.TicketForms {
-			if state.ExistsTicketForm(ticketForm.Slug) {
-				continue
-			}
-
-			exe.Step("Creating \""+ticketForm.Name+"\"", func() error {
-				//TODO: refactor, move to func
-				position, err := strconv.ParseInt(ticketForm.Position, 10, 64)
-				if err != nil {
-					exe.Error(err.Error())
-					return err
-				}
-				// get actual ticket field ID from ZenformState by slug
-				ticketFieldIDs := []int64{}
-				for _, ticketFieldIDString := range ticketForm.TicketFieldIDs {
-					ticketFieldIDs = append(ticketFieldIDs, state.TicketFields[ticketFieldIDString].ID)
-				}
-				requestPayload := zendesk.TicketForm{
-					Name:           ticketForm.Name,
-					Position:       position,
-					TicketFieldIDs: ticketFieldIDs,
-				}
-
-				result, err := zd.CreateTicketForm(requestPayload)
-				if err != nil {
-					exe.Error("Failed to create ticket form: " + ticketForm.Name)
-					exe.Error("Error: " + err.Error())
-					return err
-				}
-				state.TicketForms[ticketForm.Slug] = result
-				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
-				return nil
-			})
-		}
-		exe.Success("Created (" + fmt.Sprintf("%d", len(state.TicketForms)) + ") ticket forms")
-		return nil
-	}
-}
-
-func stepCreateTriggers(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
-	return func() error {
-		for _, trigger := range conf.Triggers {
-			if state.ExistsTrigger(trigger.Slug) {
-				continue
-			}
-
-			exe.Step("Creating \""+trigger.Title+"\"", func() error {
-				//TODO: refactor, move to func
-				position, err := strconv.ParseInt(trigger.Position, 10, 64)
-				if err != nil {
-					exe.Error(err.Error())
-					return err
-				}
-				requestPayload := zendesk.Trigger{
-					Title:    trigger.Title,
-					Position: position,
-				}
-
-				for _, triggerAll := range trigger.All {
-					allConditionPayload := zendesk.TriggerCondition{
-						Field:    state.ActualConditionFieldName(triggerAll.Field),
-						Operator: triggerAll.Operator,
-						Value:    triggerAll.Value,
-					}
-					requestPayload.Conditions.All = append(requestPayload.Conditions.All, allConditionPayload)
-				}
-
-				for _, triggerAny := range trigger.Any {
-					anyConditionPayload := zendesk.TriggerCondition{
-						Field:    state.ActualConditionFieldName(triggerAny.Field),
-						Operator: triggerAny.Operator,
-						Value:    triggerAny.Value,
-					}
-					requestPayload.Conditions.Any = append(requestPayload.Conditions.Any, anyConditionPayload)
-				}
-
-				for _, triggerAction := range trigger.Actions {
-					actionPayload := zendesk.TriggerAction{}
-					actionPayload.Field = state.ActualActionFieldName(triggerAction.Field)
-					actionPayload.Value = state.ActualActionFieldValue(actionPayload.Field, triggerAction)
-					requestPayload.Actions = append(requestPayload.Actions, actionPayload)
-				}
-
-				result, err := zd.CreateTrigger(requestPayload)
-				if err != nil {
-					exe.Error("Failed to create trigger: " + trigger.Title)
-					exe.Error("Error: " + err.Error())
-					return err
-				}
-				state.Triggers[trigger.Slug] = result
-				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
-				return nil
-			})
-		}
-		exe.Success("Created (" + fmt.Sprintf("%d", len(state.Triggers)) + ") triggers")
-		return nil
-	}
 }

--- a/command/apply.go
+++ b/command/apply.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/spf13/cobra"
+	"github.com/xflagstudio/zenform/command/common"
+	"github.com/xflagstudio/zenform/command/step"
 	"github.com/xflagstudio/zenform/config"
 )
 
@@ -28,7 +30,7 @@ var applyCommand = &cobra.Command{
 }
 
 func applyFunc(cmd *cobra.Command, args []string) {
-	exe := NewStepExecutor()
+	exe := step.NewExecutor()
 	zd, _ := zendesk.NewClient(nil)
 	zfconfig := &config.ZenformConfig{}
 	currentState := NewZenformState()
@@ -45,7 +47,7 @@ func applyFunc(cmd *cobra.Command, args []string) {
 		return nil
 	})
 
-	exe.Step("Checking zenform config", stepLoadZenformConfig(exe, zfconfig, zd))
+	exe.Step("Checking zenform config", common.StepLoadZenformConfig(exe, zfconfig, zd))
 
 	// If zfstate.json exists,
 	// recover last config data as current Zendesk state
@@ -156,7 +158,7 @@ func applyFunc(cmd *cobra.Command, args []string) {
 	})
 }
 
-func stepCreateTicketFields(exe *StepExecutor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
 	return func() error {
 		for _, ticketField := range conf.TicketFields {
 			if state.ExistsTicketField(ticketField.Slug) {
@@ -192,7 +194,7 @@ func stepCreateTicketFields(exe *StepExecutor, zd *zendesk.Client, conf config.C
 	}
 }
 
-func stepCreateTicketForms(exe *StepExecutor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
 	return func() error {
 		for _, ticketForm := range conf.TicketForms {
 			if state.ExistsTicketForm(ticketForm.Slug) {
@@ -233,7 +235,7 @@ func stepCreateTicketForms(exe *StepExecutor, zd *zendesk.Client, conf config.Co
 	}
 }
 
-func stepCreateTriggers(exe *StepExecutor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTriggers(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
 	return func() error {
 		for _, trigger := range conf.Triggers {
 			if state.ExistsTrigger(trigger.Slug) {

--- a/command/apply.go
+++ b/command/apply.go
@@ -33,7 +33,7 @@ func applyFunc(cmd *cobra.Command, args []string) {
 	exe := step.NewExecutor()
 	zd, _ := zendesk.NewClient(nil)
 	zfconfig := &config.ZenformConfig{}
-	currentState := NewZenformState()
+	currentState := config.NewZenformState()
 	var conf config.Config
 
 	// If specified zenform project directory path,
@@ -158,7 +158,7 @@ func applyFunc(cmd *cobra.Command, args []string) {
 	})
 }
 
-func stepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
 	return func() error {
 		for _, ticketField := range conf.TicketFields {
 			if state.ExistsTicketField(ticketField.Slug) {
@@ -194,7 +194,7 @@ func stepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.
 	}
 }
 
-func stepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
 	return func() error {
 		for _, ticketForm := range conf.TicketForms {
 			if state.ExistsTicketForm(ticketForm.Slug) {
@@ -235,7 +235,7 @@ func stepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.C
 	}
 }
 
-func stepCreateTriggers(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *ZenformState) func() error {
+func stepCreateTriggers(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
 	return func() error {
 		for _, trigger := range conf.Triggers {
 			if state.ExistsTrigger(trigger.Slug) {

--- a/command/apply/step_create_ticket_fields.go
+++ b/command/apply/step_create_ticket_fields.go
@@ -1,0 +1,45 @@
+package apply
+
+import (
+	"fmt"
+
+	"github.com/nukosuke/go-zendesk/zendesk"
+	"github.com/xflagstudio/zenform/command/step"
+	"github.com/xflagstudio/zenform/config"
+)
+
+func StepCreateTicketFields(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
+	return func() error {
+		for _, ticketField := range conf.TicketFields {
+			if state.ExistsTicketField(ticketField.Slug) {
+				continue
+			}
+
+			exe.Step("Creating \""+ticketField.Title+"\"", func() error {
+				//TODO: refactor, move to func
+				requestPayload := zendesk.TicketField{
+					Type:  ticketField.Type,
+					Title: ticketField.Title,
+				}
+				for _, customFieldOption := range ticketField.CustomFieldOptions {
+					requestPayload.CustomFieldOptions = append(requestPayload.CustomFieldOptions, zendesk.TicketFieldCustomFieldOption{
+						Name:  customFieldOption.Name,
+						Value: customFieldOption.Value,
+					})
+				}
+
+				result, err := zd.CreateTicketField(requestPayload)
+				if err != nil {
+					exe.Error("Failed to create ticket field: " + ticketField.Title)
+					exe.Error("Error: " + err.Error())
+					return err
+				}
+				state.TicketFields[ticketField.Slug] = result
+				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
+				return nil
+			})
+		}
+		exe.Success("Created (" + fmt.Sprintf("%d", len(state.TicketFields)) + ") ticket fields")
+		return nil
+	}
+}

--- a/command/apply/step_create_ticket_forms.go
+++ b/command/apply/step_create_ticket_forms.go
@@ -1,0 +1,51 @@
+package apply
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/nukosuke/go-zendesk/zendesk"
+	"github.com/xflagstudio/zenform/command/step"
+	"github.com/xflagstudio/zenform/config"
+)
+
+func StepCreateTicketForms(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
+	return func() error {
+		for _, ticketForm := range conf.TicketForms {
+			if state.ExistsTicketForm(ticketForm.Slug) {
+				continue
+			}
+
+			exe.Step("Creating \""+ticketForm.Name+"\"", func() error {
+				//TODO: refactor, move to func
+				position, err := strconv.ParseInt(ticketForm.Position, 10, 64)
+				if err != nil {
+					exe.Error(err.Error())
+					return err
+				}
+				// get actual ticket field ID from ZenformState by slug
+				ticketFieldIDs := []int64{}
+				for _, ticketFieldIDString := range ticketForm.TicketFieldIDs {
+					ticketFieldIDs = append(ticketFieldIDs, state.TicketFields[ticketFieldIDString].ID)
+				}
+				requestPayload := zendesk.TicketForm{
+					Name:           ticketForm.Name,
+					Position:       position,
+					TicketFieldIDs: ticketFieldIDs,
+				}
+
+				result, err := zd.CreateTicketForm(requestPayload)
+				if err != nil {
+					exe.Error("Failed to create ticket form: " + ticketForm.Name)
+					exe.Error("Error: " + err.Error())
+					return err
+				}
+				state.TicketForms[ticketForm.Slug] = result
+				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
+				return nil
+			})
+		}
+		exe.Success("Created (" + fmt.Sprintf("%d", len(state.TicketForms)) + ") ticket forms")
+		return nil
+	}
+}

--- a/command/apply/step_create_triggers.go
+++ b/command/apply/step_create_triggers.go
@@ -1,0 +1,70 @@
+package apply
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/nukosuke/go-zendesk/zendesk"
+	"github.com/xflagstudio/zenform/command/step"
+	"github.com/xflagstudio/zenform/config"
+)
+
+func StepCreateTriggers(exe *step.Executor, zd *zendesk.Client, conf config.Config, state *config.ZenformState) func() error {
+	return func() error {
+		for _, trigger := range conf.Triggers {
+			if state.ExistsTrigger(trigger.Slug) {
+				continue
+			}
+
+			exe.Step("Creating \""+trigger.Title+"\"", func() error {
+				//TODO: refactor, move to func
+				position, err := strconv.ParseInt(trigger.Position, 10, 64)
+				if err != nil {
+					exe.Error(err.Error())
+					return err
+				}
+				requestPayload := zendesk.Trigger{
+					Title:    trigger.Title,
+					Position: position,
+				}
+
+				for _, triggerAll := range trigger.All {
+					allConditionPayload := zendesk.TriggerCondition{
+						Field:    state.ActualConditionFieldName(triggerAll.Field),
+						Operator: triggerAll.Operator,
+						Value:    triggerAll.Value,
+					}
+					requestPayload.Conditions.All = append(requestPayload.Conditions.All, allConditionPayload)
+				}
+
+				for _, triggerAny := range trigger.Any {
+					anyConditionPayload := zendesk.TriggerCondition{
+						Field:    state.ActualConditionFieldName(triggerAny.Field),
+						Operator: triggerAny.Operator,
+						Value:    triggerAny.Value,
+					}
+					requestPayload.Conditions.Any = append(requestPayload.Conditions.Any, anyConditionPayload)
+				}
+
+				for _, triggerAction := range trigger.Actions {
+					actionPayload := zendesk.TriggerAction{}
+					actionPayload.Field = state.ActualActionFieldName(triggerAction.Field)
+					actionPayload.Value = state.ActualActionFieldValue(actionPayload.Field, triggerAction)
+					requestPayload.Actions = append(requestPayload.Actions, actionPayload)
+				}
+
+				result, err := zd.CreateTrigger(requestPayload)
+				if err != nil {
+					exe.Error("Failed to create trigger: " + trigger.Title)
+					exe.Error("Error: " + err.Error())
+					return err
+				}
+				state.Triggers[trigger.Slug] = result
+				exe.Success(fmt.Sprintf("Done (ID=%d)", result.ID))
+				return nil
+			})
+		}
+		exe.Success("Created (" + fmt.Sprintf("%d", len(state.Triggers)) + ") triggers")
+		return nil
+	}
+}

--- a/command/common/step_load_zenform_config.go
+++ b/command/common/step_load_zenform_config.go
@@ -1,17 +1,18 @@
-package command
+package common
 
 import (
 	"io/ioutil"
 	"os"
 
 	"github.com/nukosuke/go-zendesk/zendesk"
+	"github.com/xflagstudio/zenform/command/step"
 	"github.com/xflagstudio/zenform/config"
 	"gopkg.in/yaml.v2"
 )
 
 const zenformConfigFileName = "zenform.yml"
 
-func stepLoadZenformConfig(exe *StepExecutor, zfconfig *config.ZenformConfig, zd *zendesk.Client) func() error {
+func StepLoadZenformConfig(exe *step.Executor, zfconfig *config.ZenformConfig, zd *zendesk.Client) func() error {
 	return func() error {
 		if _, err := os.Stat(zenformConfigFileName); os.IsNotExist(err) {
 			exe.Error(zenformConfigFileName + " Not Found")

--- a/command/step/executor.go
+++ b/command/step/executor.go
@@ -1,24 +1,29 @@
-package command
+package step
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
-type StepExecutor struct {
+// Executor runs steps sequentially by Step method and manage step nest level
+//   to pretty print the result.
+type Executor struct {
 	indentLevel int
 	padding     string
 }
 
-func NewStepExecutor() *StepExecutor {
-	return &StepExecutor{
+// NewExecutor creates initialized Executor instance.
+func NewExecutor() *Executor {
+	return &Executor{
 		indentLevel: 0,
 		padding:     "    ", // padding left spaces
 	}
 }
 
-func (exe *StepExecutor) Step(msgOnStart string, stepFunc func() error) error {
+// Step executes stepFunc and returns its result.
+func (exe *Executor) Step(msgOnStart string, stepFunc func() error) error {
 	// switch arrow type
 	var arrow string
 	if exe.indentLevel == 0 {
@@ -41,21 +46,22 @@ func (exe *StepExecutor) Step(msgOnStart string, stepFunc func() error) error {
 	return nil
 }
 
-func (exe *StepExecutor) StepIf(condition bool, msgOnStart string, stepFunc func() error) error {
+// StepIf is conditional execution of step. If condition is false, this step will be skipped.
+func (exe *Executor) StepIf(condition bool, msgOnStart string, stepFunc func() error) error {
 	if !condition {
 		return nil
 	}
 	return exe.Step(msgOnStart, stepFunc)
 }
 
-func (exe *StepExecutor) Info(msg string) {
+func (exe *Executor) Info(msg string) {
 	fmt.Println(strings.Repeat(exe.padding, exe.indentLevel) + msg)
 }
 
-func (exe *StepExecutor) Error(msg string) {
+func (exe *Executor) Error(msg string) {
 	color.Red(strings.Repeat(exe.padding, exe.indentLevel) + msg)
 }
 
-func (exe *StepExecutor) Success(msg string) {
+func (exe *Executor) Success(msg string) {
 	color.Green(strings.Repeat(exe.padding, exe.indentLevel) + msg)
 }

--- a/config/zenform_state.go
+++ b/config/zenform_state.go
@@ -1,10 +1,9 @@
-package command
+package config
 
 import (
 	"fmt"
 
 	"github.com/nukosuke/go-zendesk/zendesk"
-	"github.com/xflagstudio/zenform/config"
 )
 
 // map of slug and each resource instance
@@ -54,7 +53,7 @@ func (state ZenformState) ActualActionFieldName(systemFieldTypeOrSlug string) st
 
 // ActualActionFieldValue takes field type and TriggerActionConfig.
 // It returns field value according to field type
-func (state ZenformState) ActualActionFieldValue(fieldType string, triggerAction config.TriggerActionConfig) interface{} {
+func (state ZenformState) ActualActionFieldValue(fieldType string, triggerAction TriggerActionConfig) interface{} {
 	switch fieldType {
 	case "notification_user": // []string
 		return triggerAction.Value


### PR DESCRIPTION
`command` directory is becoming more and more dirty. Step executor and all steps should be separated into appropriate packages. It's ideal that one step is in one file.

changes:
- created command subdirectories for step
- moved ZenformState struct to config package
- moved step func to a separated file (`command/apply/*.go`, `command/common/*.go`)
- renamed `StepExecutor` to simply `Executor` and moved it to `command/step/`