### PR TITLE
Add authentication for pulling image from Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ defaults: &defaults
   working_directory: /go/src/github.com/xflagstudio/zenform
   docker:
     - image: circleci/golang:1.12
+      auth:
+        username: $DOCKERHUB_USERNAME
+        password: $DOCKERHUB_PASSWORD
       environment:
         GO111MODULE: "on"
 


### PR DESCRIPTION
Add authentication to avoid Docker Hub download rate limit.
User name and password of Docker Hub are already registered as environment variables.

https://docs.docker.com/docker-hub/download-rate-limit/